### PR TITLE
tech: Removes the PactSwiftToolbox dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,6 @@ let package = Package(
 	],
 
 	dependencies: [
-		.package(name: "PactSwiftToolbox", url: "https://github.com/surpher/PactSwiftToolbox.git", from: "0.2.0"),
 		.package(name: "PactMockServer", url: "https://github.com/surpher/PactMockServer.git", from: "0.1.0"),
 	],
 
@@ -44,7 +43,6 @@ let package = Package(
 			name: "PactSwiftMockServerLinux",
 			dependencies: [
 				"PactMockServer",
-				"PactSwiftToolbox",
 			],
 			path: "./Sources"
 		),

--- a/PactSwiftMockServer.xcfilelist
+++ b/PactSwiftMockServer.xcfilelist
@@ -1,5 +1,8 @@
 $(SRCROOT)/Sources/Verifier.swift
 $(SRCROOT)/Sources/MockServer.swift
+$(SRCROOT)/Sources/Toolbox/SocketBinder.swift
+$(SRCROOT)/Sources/Toolbox/Logger.swift
+$(SRCROOT)/Sources/Toolbox/PactFileManager.swift
 $(SRCROOT)/Sources/Model/TransferProtocol.swift
 $(SRCROOT)/Sources/Model/VerificationErrorHandler.swift
 $(SRCROOT)/Sources/Model/ProviderVerificationError.swift

--- a/PactSwiftMockServer.xcodeproj/project.pbxproj
+++ b/PactSwiftMockServer.xcodeproj/project.pbxproj
@@ -3,17 +3,15 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
 		AD1597FD2648DE0E007CFAA5 /* PactSwiftMockServer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AD1597F32648DE0E007CFAA5 /* PactSwiftMockServer.framework */; };
 		AD1598042648DE0E007CFAA5 /* PactSwiftMockServer.h in Headers */ = {isa = PBXBuildFile; fileRef = AD1597F62648DE0E007CFAA5 /* PactSwiftMockServer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AD1598122648DF36007CFAA5 /* PactSwiftToolbox in Frameworks */ = {isa = PBXBuildFile; productRef = AD1598112648DF36007CFAA5 /* PactSwiftToolbox */; };
 		AD1598212648DF73007CFAA5 /* PactSwiftMockServer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AD1598182648DF73007CFAA5 /* PactSwiftMockServer.framework */; };
 		AD1598312648E32F007CFAA5 /* MockServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD1598302648E32F007CFAA5 /* MockServer.swift */; };
 		AD1598322648E32F007CFAA5 /* MockServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD1598302648E32F007CFAA5 /* MockServer.swift */; };
-		AD1598372648E59E007CFAA5 /* PactSwiftToolbox in Frameworks */ = {isa = PBXBuildFile; productRef = AD1598362648E59E007CFAA5 /* PactSwiftToolbox */; };
 		AD15983B2648E72A007CFAA5 /* TransferProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD15983A2648E72A007CFAA5 /* TransferProtocol.swift */; };
 		AD15983C2648E72A007CFAA5 /* TransferProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD15983A2648E72A007CFAA5 /* TransferProtocol.swift */; };
 		AD15983E2648EA2C007CFAA5 /* MockServerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD15983D2648EA2C007CFAA5 /* MockServerError.swift */; };
@@ -24,13 +22,21 @@
 		AD1598522648F2E1007CFAA5 /* MockServerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD1598512648F2E1007CFAA5 /* MockServerTests.swift */; };
 		AD1598532648F2E1007CFAA5 /* MockServerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD1598512648F2E1007CFAA5 /* MockServerTests.swift */; };
 		AD38D300264A33E800124396 /* PactSwiftMockServer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AD38D2F7264A33E800124396 /* PactSwiftMockServer.framework */; };
-		AD38D30F264A33F200124396 /* PactSwiftToolbox in Frameworks */ = {isa = PBXBuildFile; productRef = AD38D30E264A33F200124396 /* PactSwiftToolbox */; };
 		AD63D08226A02C28002682EB /* libpact_ffi.a in Frameworks */ = {isa = PBXBuildFile; fileRef = AD63D08126A02C28002682EB /* libpact_ffi.a */; };
 		AD63D08F26A02C64002682EB /* libpact_ffi.a in Frameworks */ = {isa = PBXBuildFile; fileRef = AD9336A5269C33EB0004EBD8 /* libpact_ffi.a */; };
 		AD933643269C2DD80004EBD8 /* libpact_ffi.a in Frameworks */ = {isa = PBXBuildFile; fileRef = AD933642269C2DD80004EBD8 /* libpact_ffi.a */; };
 		AD93364D269C2EC30004EBD8 /* pact_ffi.h in Headers */ = {isa = PBXBuildFile; fileRef = AD93364C269C2EC30004EBD8 /* pact_ffi.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AD93364E269C2EC30004EBD8 /* pact_ffi.h in Headers */ = {isa = PBXBuildFile; fileRef = AD93364C269C2EC30004EBD8 /* pact_ffi.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AD93364F269C2EC30004EBD8 /* pact_ffi.h in Headers */ = {isa = PBXBuildFile; fileRef = AD93364C269C2EC30004EBD8 /* pact_ffi.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AD957F3628A23B0B00860AD1 /* PactFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD957F3528A23B0B00860AD1 /* PactFileManager.swift */; };
+		AD957F3728A23B0B00860AD1 /* PactFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD957F3528A23B0B00860AD1 /* PactFileManager.swift */; };
+		AD957F3828A23B0B00860AD1 /* PactFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD957F3528A23B0B00860AD1 /* PactFileManager.swift */; };
+		AD957F3A28A23B8400860AD1 /* SocketBinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD957F3928A23B8400860AD1 /* SocketBinder.swift */; };
+		AD957F3B28A23B8400860AD1 /* SocketBinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD957F3928A23B8400860AD1 /* SocketBinder.swift */; };
+		AD957F3C28A23B8400860AD1 /* SocketBinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD957F3928A23B8400860AD1 /* SocketBinder.swift */; };
+		AD957F3E28A23BD600860AD1 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD957F3D28A23BD600860AD1 /* Logger.swift */; };
+		AD957F3F28A23BD600860AD1 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD957F3D28A23BD600860AD1 /* Logger.swift */; };
+		AD957F4028A23BD600860AD1 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD957F3D28A23BD600860AD1 /* Logger.swift */; };
 		ADB97FD726493D1800C54CA9 /* VerificationErrorTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADB97FD626493D1800C54CA9 /* VerificationErrorTypeTests.swift */; };
 		ADB97FD826493D1800C54CA9 /* VerificationErrorTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADB97FD626493D1800C54CA9 /* VerificationErrorTypeTests.swift */; };
 		ADB97FDA26493D5900C54CA9 /* MockServerErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADB97FD926493D5900C54CA9 /* MockServerErrorTests.swift */; };
@@ -119,6 +125,9 @@
 		AD933642269C2DD80004EBD8 /* libpact_ffi.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libpact_ffi.a; sourceTree = "<group>"; };
 		AD93364C269C2EC30004EBD8 /* pact_ffi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pact_ffi.h; sourceTree = "<group>"; };
 		AD9336A5269C33EB0004EBD8 /* libpact_ffi.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libpact_ffi.a; sourceTree = "<group>"; };
+		AD957F3528A23B0B00860AD1 /* PactFileManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PactFileManager.swift; sourceTree = "<group>"; };
+		AD957F3928A23B8400860AD1 /* SocketBinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketBinder.swift; sourceTree = "<group>"; };
+		AD957F3D28A23BD600860AD1 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		ADB97FD626493D1800C54CA9 /* VerificationErrorTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerificationErrorTypeTests.swift; sourceTree = "<group>"; };
 		ADB97FD926493D5900C54CA9 /* MockServerErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockServerErrorTests.swift; sourceTree = "<group>"; };
 		ADBEF2EA2648FB0600486C4A /* Target-macOS-Tests-Shared.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Target-macOS-Tests-Shared.xcconfig"; sourceTree = "<group>"; };
@@ -154,7 +163,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				AD1598122648DF36007CFAA5 /* PactSwiftToolbox in Frameworks */,
 				AD63D08F26A02C64002682EB /* libpact_ffi.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -172,7 +180,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				AD933643269C2DD80004EBD8 /* libpact_ffi.a in Frameworks */,
-				AD1598372648E59E007CFAA5 /* PactSwiftToolbox in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -188,7 +195,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				AD38D30F264A33F200124396 /* PactSwiftToolbox in Frameworks */,
 				AD63D08226A02C28002682EB /* libpact_ffi.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -262,6 +268,7 @@
 				AD1598382648E690007CFAA5 /* Headers */,
 				AD1598302648E32F007CFAA5 /* MockServer.swift */,
 				AD1598392648E6DB007CFAA5 /* Model */,
+				AD957F3428A23AF300860AD1 /* Toolbox */,
 				ADE2550F26CE335400FA21A9 /* Verifier.swift */,
 			);
 			path = Sources;
@@ -349,6 +356,16 @@
 			path = "iOS-device";
 			sourceTree = "<group>";
 		};
+		AD957F3428A23AF300860AD1 /* Toolbox */ = {
+			isa = PBXGroup;
+			children = (
+				AD957F3D28A23BD600860AD1 /* Logger.swift */,
+				AD957F3528A23B0B00860AD1 /* PactFileManager.swift */,
+				AD957F3928A23B8400860AD1 /* SocketBinder.swift */,
+			);
+			path = Toolbox;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -398,7 +415,6 @@
 			);
 			name = PactSwiftMockServer_iOS;
 			packageProductDependencies = (
-				AD1598112648DF36007CFAA5 /* PactSwiftToolbox */,
 			);
 			productName = PactSwiftMockServer;
 			productReference = AD1597F32648DE0E007CFAA5 /* PactSwiftMockServer.framework */;
@@ -438,7 +454,6 @@
 			);
 			name = PactSwiftMockServer_macOS;
 			packageProductDependencies = (
-				AD1598362648E59E007CFAA5 /* PactSwiftToolbox */,
 			);
 			productName = PactSwiftMockServer_macOS;
 			productReference = AD1598182648DF73007CFAA5 /* PactSwiftMockServer.framework */;
@@ -477,7 +492,6 @@
 			);
 			name = PactSwiftMockServer_iphoneos;
 			packageProductDependencies = (
-				AD38D30E264A33F200124396 /* PactSwiftToolbox */,
 			);
 			productName = PactSwiftMockServer_iphoneos;
 			productReference = AD38D2F7264A33E800124396 /* PactSwiftMockServer.framework */;
@@ -544,7 +558,6 @@
 			);
 			mainGroup = AD1597E92648DE0E007CFAA5;
 			packageReferences = (
-				AD1598102648DF36007CFAA5 /* XCRemoteSwiftPackageReference "PactSwiftToolbox" */,
 			);
 			productRefGroup = AD1597F42648DE0E007CFAA5 /* Products */;
 			projectDirPath = "";
@@ -608,6 +621,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		ADE254FC26CDE3A100FA21A9 /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -626,6 +640,7 @@
 		};
 		ADE254FD26CDE3C700FA21A9 /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -656,8 +671,11 @@
 				AD15983E2648EA2C007CFAA5 /* MockServerError.swift in Sources */,
 				AD15983B2648E72A007CFAA5 /* TransferProtocol.swift in Sources */,
 				ADBEF3032648FCF200486C4A /* MismatchErrorType.swift in Sources */,
+				AD957F3E28A23BD600860AD1 /* Logger.swift in Sources */,
+				AD957F3A28A23B8400860AD1 /* SocketBinder.swift in Sources */,
 				ADBEF3072648FCF200486C4A /* RequestError.swift in Sources */,
 				ADE2551026CE335400FA21A9 /* Verifier.swift in Sources */,
+				AD957F3628A23B0B00860AD1 /* PactFileManager.swift in Sources */,
 				AD1598312648E32F007CFAA5 /* MockServer.swift in Sources */,
 				ADBEF2FA2648FCBC00486C4A /* VerificationErrorHandler.swift in Sources */,
 				ADE2550326CE334B00FA21A9 /* StateHandler.swift in Sources */,
@@ -687,8 +705,11 @@
 				AD15983F2648EA2C007CFAA5 /* MockServerError.swift in Sources */,
 				AD15983C2648E72A007CFAA5 /* TransferProtocol.swift in Sources */,
 				ADBEF3042648FCF200486C4A /* MismatchErrorType.swift in Sources */,
+				AD957F3F28A23BD600860AD1 /* Logger.swift in Sources */,
+				AD957F3B28A23B8400860AD1 /* SocketBinder.swift in Sources */,
 				ADBEF3082648FCF200486C4A /* RequestError.swift in Sources */,
 				ADE2551126CE335400FA21A9 /* Verifier.swift in Sources */,
+				AD957F3728A23B0B00860AD1 /* PactFileManager.swift in Sources */,
 				AD1598322648E32F007CFAA5 /* MockServer.swift in Sources */,
 				ADBEF2FB2648FCBC00486C4A /* VerificationErrorHandler.swift in Sources */,
 				ADE2550426CE334B00FA21A9 /* StateHandler.swift in Sources */,
@@ -718,8 +739,11 @@
 				ADD7CB0B264B4A080091A286 /* VerificationErrorHandler.swift in Sources */,
 				ADD7CB13264B4A080091A286 /* VerificationErrorType.swift in Sources */,
 				ADD7CB11264B4A080091A286 /* VerificationError.swift in Sources */,
+				AD957F4028A23BD600860AD1 /* Logger.swift in Sources */,
+				AD957F3C28A23B8400860AD1 /* SocketBinder.swift in Sources */,
 				ADD7CB12264B4A080091A286 /* MockServer.swift in Sources */,
 				ADE2551226CE335400FA21A9 /* Verifier.swift in Sources */,
+				AD957F3828A23B0B00860AD1 /* PactFileManager.swift in Sources */,
 				ADD7CB14264B4A080091A286 /* MismatchErrorType.swift in Sources */,
 				ADD7CB10264B4A080091A286 /* TransferProtocol.swift in Sources */,
 				ADE2550526CE334B00FA21A9 /* StateHandler.swift in Sources */,
@@ -930,35 +954,6 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
-
-/* Begin XCRemoteSwiftPackageReference section */
-		AD1598102648DF36007CFAA5 /* XCRemoteSwiftPackageReference "PactSwiftToolbox" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/surpher/PactSwiftToolbox";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.1.0;
-			};
-		};
-/* End XCRemoteSwiftPackageReference section */
-
-/* Begin XCSwiftPackageProductDependency section */
-		AD1598112648DF36007CFAA5 /* PactSwiftToolbox */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = AD1598102648DF36007CFAA5 /* XCRemoteSwiftPackageReference "PactSwiftToolbox" */;
-			productName = PactSwiftToolbox;
-		};
-		AD1598362648E59E007CFAA5 /* PactSwiftToolbox */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = AD1598102648DF36007CFAA5 /* XCRemoteSwiftPackageReference "PactSwiftToolbox" */;
-			productName = PactSwiftToolbox;
-		};
-		AD38D30E264A33F200124396 /* PactSwiftToolbox */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = AD1598102648DF36007CFAA5 /* XCRemoteSwiftPackageReference "PactSwiftToolbox" */;
-			productName = PactSwiftToolbox;
-		};
-/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = AD1597EA2648DE0E007CFAA5 /* Project object */;
 }

--- a/Sources/MockServer.swift
+++ b/Sources/MockServer.swift
@@ -16,7 +16,6 @@
 //
 
 import Foundation
-@_implementationOnly import PactSwiftToolbox
 
 #if SWIFT_PACKAGE
 import PactMockServer

--- a/Sources/Toolbox/Logger.swift
+++ b/Sources/Toolbox/Logger.swift
@@ -1,0 +1,77 @@
+//
+//  Created by Marko Justinek on 9/8/2022.
+//  Copyright © 2022 Marko Justinek. All rights reserved.
+//
+//  Permission to use, copy, modify, and/or distribute this software for any
+//  purpose with or without fee is hereby granted, provided that the above
+//  copyright notice and this permission notice appear in all copies.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+//  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+//  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+//  SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+//  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+//  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+//  IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+//
+
+import Foundation
+import os.log
+
+enum Logger {
+
+	/// Logs Pact related messages.
+	///
+	/// Looks for environment variable `PACT_ENABLE_LOGGING = "all"`. Can be set in project's scheme. Uses `os_log` on Apple platforms.
+	///
+	/// - Parameters:
+	///    - message: The message to log
+	///    - data: Data to log
+	///
+	static func log(message: String, data: Data? = nil) {
+		guard case .all = PactLoggingLevel(value: ProcessInfo.processInfo.environment["PACT_ENABLE_LOGGING"]) else {
+			return
+		}
+
+		let stringData = data.flatMap { String(data: $0, encoding: .utf8) } ?? ""
+
+		if #available(iOS 10, OSX 10.14, *) {
+			#if !os(Linux)
+			os_log(
+				"PactSwift: %{private}s",
+				log: .default,
+				type: .default,
+				"\(message): \(stringData)"
+			)
+			#else
+			print(message: "PactSwift: \(message)\n\(stringData)")
+			#endif
+
+		} else {
+			print(message: "PactSwift: \(message)\n\(stringData)")
+		}
+	}
+
+}
+
+// MARK: - Private
+
+private extension Logger {
+
+	static func print(message: String) {
+		debugPrint(message)
+	}
+
+	enum PactLoggingLevel: String {
+		case all
+		case disabled
+
+		init(value: String?) {
+			switch value {
+			case "all": self = .all
+			default: self = .disabled
+			}
+		}
+	}
+
+}

--- a/Sources/Toolbox/PactFileManager.swift
+++ b/Sources/Toolbox/PactFileManager.swift
@@ -1,0 +1,80 @@
+//
+//  Created by Marko Justinek on 9/8/2022.
+//  Copyright © 2022 Marko Justinek. All rights reserved.
+//
+//  Permission to use, copy, modify, and/or distribute this software for any
+//  purpose with or without fee is hereby granted, provided that the above
+//  copyright notice and this permission notice appear in all copies.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+//  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+//  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+//  SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+//  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+//  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+//  IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+//
+
+import Foundation
+
+enum PactFileManager {
+
+	/// Where Pact contracts are written to.
+	///
+	/// macOS:
+	///
+	/// Running tests for macOS it will default to app's Documents folder:
+	///
+	/// (eg: `~/Library/Containers/au.com.pact-foundation.Pact-macOS-Example/Data/Documents`)
+	///
+	/// If testing a sandboxed macOS app, this is the default location and it can not be overwritten.
+	/// If testing a macOS app that is not sandboxed, define a `PACT_OUTPUT_DIR` Environment Variable (in the scheme)
+	/// with the path to where you want Pact contracts to be written to.
+	///
+	/// iOS/tvOS or non-Xcode project:
+	///
+	/// Default location where Pact contracts are written is `/tmp/pacts` and can be overwritten
+	/// with a `PACT_OUTPUT_DIR` environment variable set to an absolute path (eg: `$(PROJECT_DIR)/tmp/pacts`).
+	///
+	static var pactDirectoryPath: String {
+		#if os(macOS) || os(OSX)
+		let defaultPath = NSHomeDirectory() + "/Documents"
+		if isSandboxed {
+			return defaultPath
+		}
+		return ProcessInfo.processInfo.environment["PACT_OUTPUT_DIR"] ?? defaultPath
+		#else
+		return ProcessInfo.processInfo.environment["PACT_OUTPUT_DIR"] ?? "/tmp/pacts"
+		#endif
+	}
+
+	/// Returns true if the directory where Pact contracts are set to be written to exists.
+	/// If it does not exists, it attempts to create it and if successful, returns true.
+	///
+	static func isPactDirectoryAvailable() -> Bool {
+		if FileManager.default.fileExists(atPath: pactDirectoryPath) == false {
+			do {
+				try FileManager.default.createDirectory(at: pactDirectoryURL, withIntermediateDirectories: true, attributes: nil)
+			} catch let error as NSError {
+				debugPrint("Directory \(pactDirectoryURL) could not be created! \(error.localizedDescription)")
+				return false
+			}
+		}
+		return true
+	}
+
+}
+
+private extension PactFileManager {
+
+	static var pactDirectoryURL: URL {
+		URL(fileURLWithPath: pactDirectoryPath, isDirectory: true)
+	}
+
+	/// Returns true if app is sandboxed
+	static var isSandboxed: Bool {
+		let environment = ProcessInfo.processInfo.environment
+		return environment["APP_SANDBOX_CONTAINER_ID"] != nil
+	}
+
+}

--- a/Sources/Toolbox/SocketBinder.swift
+++ b/Sources/Toolbox/SocketBinder.swift
@@ -1,0 +1,123 @@
+//
+//  Created by Marko Justinek on 9/8/2022.
+//  Copyright © 2022 Marko Justinek. All rights reserved.
+//
+//  Permission to use, copy, modify, and/or distribute this software for any
+//  purpose with or without fee is hereby granted, provided that the above
+//  copyright notice and this permission notice appear in all copies.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+//  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+//  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+//  SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+//  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+//  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+//  IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+//
+
+import Foundation
+
+enum SocketBinder {
+
+	public static func unusedPort() -> Int32 {
+		#if os(Linux)
+		return getAvailablePort()
+		#else
+		var port = randomPort
+		var (available, _) = tcpPortAvailable(port: port)
+		while !available {
+			port = randomPort
+			(available, _) = tcpPortAvailable(port: port)
+		}
+		return Int32(port)
+		#endif
+	}
+
+}
+
+// MARK: - Private
+
+private extension SocketBinder {
+
+	// MARK: - Linux
+
+	#if os(Linux)
+
+	static func getAvailablePort() -> Int32 {
+		let task = Process()
+		task.executableURL = URL(fileURLWithPath: "/bin/bash")
+		task.arguments = ["-c", #"comm -23 <(seq 49152 65535) <(ss -tan | awk '{print $4}' | cut -d':' -f2 | grep "[0-9]\{1,5\}" | sort | uniq) | shuf | head -n 1"#]
+
+		let pipe = Pipe()
+		task.standardOutput = pipe
+		task.standardError = pipe
+		do {
+			try task.run()
+		} catch {
+			fatalError(error.localizedDescription)
+		}
+
+		let data = pipe.fileHandleForReading.readDataToEndOfFile()
+		let output = String(data: data, encoding: .utf8)
+		task.waitUntilExit()
+
+		if let lines = output?.split(separator: "\n"), lines.count == 1, let port = Int32(lines[0]) {
+			return port
+		} else {
+			fatalError("Unable to find an available port! Please raise an issue at https://github.com/surpher/PactSwiftToolbox.")
+		}
+	}
+
+	#else
+
+	// MARK: - Darwin
+
+	static var randomPort: in_port_t {
+		in_port_t(arc4random_uniform(2_000) + 4_000) // swiftlint:disable:this legacy_random
+	}
+
+	// The following code block referenced from: https://stackoverflow.com/a/49728137
+	static func tcpPortAvailable(port: in_port_t) -> (Bool, descr: String) {
+		let socketFileDescriptor = socket(AF_INET, SOCK_STREAM, 0)
+		guard socketFileDescriptor != -1 else {
+			return (false, "SocketCreationFailed: \(descriptionOfLastError())")
+		}
+
+		var addr = sockaddr_in()
+		let sizeOfSockkAddr = MemoryLayout<sockaddr_in>.size
+		addr.sin_len = __uint8_t(sizeOfSockkAddr)
+		addr.sin_family = sa_family_t(AF_INET)
+		addr.sin_port = Int(OSHostByteOrder()) == OSLittleEndian ? _OSSwapInt16(port) : port
+		addr.sin_addr = in_addr(s_addr: inet_addr("0.0.0.0"))
+		addr.sin_zero = (0, 0, 0, 0, 0, 0, 0, 0)
+		var bindAddress = sockaddr()
+		memcpy(&bindAddress, &addr, Int(sizeOfSockkAddr))
+
+		if Darwin.bind(socketFileDescriptor, &bindAddress, socklen_t(sizeOfSockkAddr)) == -1 {
+			let details = descriptionOfLastError()
+			release(socket: socketFileDescriptor)
+			return (false, "\(port), BindFailed, \(details)")
+		}
+
+		if listen(socketFileDescriptor, SOMAXCONN ) == -1 {
+			let details = descriptionOfLastError()
+			release(socket: socketFileDescriptor)
+			return (false, "\(port), ListenFailed, \(details)")
+		}
+
+		release(socket: socketFileDescriptor)
+		return (true, "\(port) is free for use")
+	}
+
+	static func release(socket: Int32) {
+		Darwin.shutdown(socket, SHUT_RDWR)
+		close(socket)
+	}
+
+	static func descriptionOfLastError() -> String {
+		String(cString: (UnsafePointer(strerror(errno))))
+	}
+
+	#endif
+
+}

--- a/Sources/Verifier.swift
+++ b/Sources/Verifier.swift
@@ -16,7 +16,6 @@
 //
 
 import Foundation
-@_implementationOnly import PactSwiftToolbox
 
 #if SWIFT_PACKAGE
 import PactMockServer


### PR DESCRIPTION
Both `PactSwift` and `PactSwiftMockService` were importing `PactSwiftToolbox` that vended three public classes. That created an unwanted diamond dependency graph. Classes were brought into the respective projects as internal classes to be used. This will remove the diamond graph and reduce remove a package.